### PR TITLE
fix for WKWebView

### DIFF
--- a/src/providers/image-loader.ts
+++ b/src/providers/image-loader.ts
@@ -216,9 +216,10 @@ export class ImageLoader {
         if (this.shouldIndex) {
           this.addFileToIndex(file).then(this.maintainCacheSize.bind(this));
         }
-
-        currentItem.resolve(localPath);
-        done();
+        this.getCachedImagePath(currentItem.imageUrl).then((localUrl) => {
+          currentItem.resolve(localUrl);
+          done();
+        });
       })
       .catch((e) => {
         currentItem.reject();


### PR DESCRIPTION
When image is downloaded, it's path should be retreived depending on - is it WKWebView or not. What is done in getCachedImagePath. But in processQueue method you only return plain path 'file://...', which is not working in WKWebView. [This](https://github.com/zyramedia/ionic-image-loader/issues/22) will be fixed with this commit